### PR TITLE
Add min_request_par_child like Starlet

### DIFF
--- a/lib/Qudo/Parallel/Manager.pm
+++ b/lib/Qudo/Parallel/Manager.pm
@@ -82,8 +82,6 @@ sub run {
                 if (my $min = $self->{min_request_par_child}) {
                     srand((rand() * 2 ** 30) ^ $$ ^ time);
                     $max -= int(($max - $min + 1) * rand);
-                } else {
-                    $max;
                 }
                 $max;
             };

--- a/lib/Qudo/Parallel/Manager.pm
+++ b/lib/Qudo/Parallel/Manager.pm
@@ -184,7 +184,7 @@ Qudo::Parallel::Manager - auto control forking manager process.
       max_workers            => 5,
       min_spare_workers      => 1,
       max_spare_workers      => 5,
-      max_request_par_chiled => 30,
+      max_request_par_child  => 30,
       auto_load_worker       => 1,
       admin                  => 1,
       debug                  => 1,

--- a/lib/Qudo/Parallel/Manager.pm
+++ b/lib/Qudo/Parallel/Manager.pm
@@ -185,6 +185,7 @@ Qudo::Parallel::Manager - auto control forking manager process.
       min_spare_workers      => 1,
       max_spare_workers      => 5,
       max_request_par_child  => 30,
+      min_request_par_child  => 0,
       auto_load_worker       => 1,
       admin                  => 1,
       debug                  => 1,


### PR DESCRIPTION
I think `min_request_par_child` option is useful
to prevent forked processes are blowed up.

Code is same as starlet's :-)
